### PR TITLE
make image tag support svg+xml image and use MemoryStream not temp file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ Generated_Code #added for RIA/Silverlight projects
 _UpgradeReport_Files/
 Backup*/
 UpgradeLog*.XML
+/.vs

--- a/Svg2Xaml/Properties/AssemblyInfo.cs
+++ b/Svg2Xaml/Properties/AssemblyInfo.cs
@@ -36,5 +36,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Svg2Xaml")]
 [assembly: AssemblyCopyright("Copyright (C) 2009-2011 Boris Richter")]
 [assembly: Guid("52a36e87-0e39-4878-86bc-1bfe9e648e7c")]
-[assembly: AssemblyVersion("0.3.0.2")]
+[assembly: AssemblyVersion("0.3.0.6")]
 

--- a/Svg2Xaml/SvgDrawableContainerBaseElement.cs
+++ b/Svg2Xaml/SvgDrawableContainerBaseElement.cs
@@ -350,8 +350,8 @@ namespace Svg2Xaml
       if(Transform != null)
         drawing_group.Transform = Transform.ToTransform();
 
-      //if (ViewBox != null)
-      //    drawing_group.Children.Add(ViewBox.Process());
+      if (ViewBox != null)
+          drawing_group.Children.Add(ViewBox.Process());
 
       foreach(SvgBaseElement child_element in Children)
       {

--- a/Svg2Xaml/SvgDrawableContainerBaseElement.cs
+++ b/Svg2Xaml/SvgDrawableContainerBaseElement.cs
@@ -44,7 +44,9 @@ namespace Svg2Xaml
   {
 
     //==========================================================================
-    public readonly SvgViewbox ViewBox = new SvgViewbox(new Rect(0, 0, 0, 0)); 
+    public readonly SvgViewbox ViewBox = new SvgViewbox(new Rect(0, 0, 0, 0));
+    public readonly SvgLength Width = null;
+    public readonly SvgLength Height = null;
     public readonly SvgLength Opacity = new SvgLength(1.0);
     public readonly SvgLength FillOpacity = new SvgLength(1.0);
     public readonly SvgLength StrokeOpacity = new SvgLength(1.0);
@@ -306,11 +308,35 @@ namespace Svg2Xaml
             throw new NotImplementedException();
         }
 
-      // color, color-interpolation, color-rendering
+            // color, color-interpolation, color-rendering
+            
+            XAttribute width_attribute = drawableContainerElement.Attribute("width");
+            if (width_attribute != null)
+                Width = SvgLength.Parse(width_attribute.Value);
+            XAttribute height_attribute = drawableContainerElement.Attribute("height");
+            if (height_attribute != null)
+                Height = SvgLength.Parse(height_attribute.Value);
 
-      // viewBox attribute
-      // preserveAspectRatio attribute
-
+            XAttribute preserveAspectRatio_attribute = drawableContainerElement.Attribute("preserveAspectRatio");
+            if (preserveAspectRatio_attribute != null)
+            {
+                switch (preserveAspectRatio_attribute.Value)
+                {
+                    case "none":
+                        if (Width != null && Height != null)
+                        {
+                            var scaleTransform = new SvgScaleTransform(
+                                Width.ToDouble() / ViewBox.Value.Width,
+                                Height.ToDouble() / ViewBox.Value.Height);
+                            Width.ToDouble();
+                            if (Transform == null)
+                                Transform = scaleTransform;
+                            else
+                                Transform = new SvgTransformGroup(new[] { Transform, scaleTransform });
+                        }
+                        break;
+                }
+            }
       // overflow
 
     }

--- a/Svg2Xaml/SvgImageElement.cs
+++ b/Svg2Xaml/SvgImageElement.cs
@@ -118,6 +118,10 @@ namespace Svg2Xaml
                 DataType = "png";
                 break;
 
+              case "svg+xml":
+                DataType = "svg+xml";
+                break;
+
               default:
                 throw new NotSupportedException(String.Format("Unsupported type: {0}", type));
             }
@@ -129,18 +133,29 @@ namespace Svg2Xaml
     //==========================================================================
     public override Drawing GetBaseDrawing()
     {
-      if(Data == null)
-        return null;
-
-      string temp_file = Path.GetTempFileName();
-      using(FileStream file_stream = new FileStream(temp_file, FileMode.Create, FileAccess.Write))
-      using(BinaryWriter writer = new BinaryWriter(file_stream))
-        writer.Write(Data);
-
-      return new ImageDrawing(new BitmapImage(new Uri(temp_file)), new Rect(
-        new Point(X.ToDouble(), Y.ToDouble()),
-        new Size(Width.ToDouble(), Height.ToDouble())
-        ));
+        if (Data == null)
+          return null;
+        ImageSource imageSource = null;
+        switch (DataType)
+        {
+          case "jpeg":
+          case "png":
+              var bmp = new BitmapImage();
+              bmp.BeginInit();
+              bmp.StreamSource = new MemoryStream(Data);
+              bmp.EndInit();
+              imageSource = bmp;
+              break;
+          case "svg+xml":
+              imageSource = SvgReader.Load(new MemoryStream(Data));
+              break;
+        }
+        if (imageSource == null)
+          return null;
+        return new ImageDrawing(imageSource, new Rect(
+                      new Point(X.ToDouble(), Y.ToDouble()),
+                      new Size(Width.ToDouble(), Height.ToDouble())
+                      ));
     }
 
     //==========================================================================

--- a/Svg2Xaml/SvgRotateTransform.cs
+++ b/Svg2Xaml/SvgRotateTransform.cs
@@ -42,17 +42,20 @@ namespace Svg2Xaml
   {
     //==========================================================================
     public readonly double Angle;
-
+    public readonly double CenterX;
+    public readonly double CenterY;
     //==========================================================================
-    public SvgRotateTransform(double angle)
+    public SvgRotateTransform(double angle,double centerX=0,double centerY=0)
     {
       Angle = angle;
+      CenterX = centerX;
+      CenterY = centerY;
     }
 
     //==========================================================================
     public override Transform ToTransform()
     {
-      return new RotateTransform(Angle);
+      return new RotateTransform(Angle,CenterX,CenterY);
     }
 
     //==========================================================================
@@ -62,7 +65,10 @@ namespace Svg2Xaml
 
       if(tokens.Length == 1)
         return new SvgRotateTransform(Double.Parse(tokens[0].Trim(), CultureInfo.InvariantCulture.NumberFormat));
-      
+      else if(tokens.Length == 3)
+        return new SvgRotateTransform(Double.Parse(tokens[0].Trim(), CultureInfo.InvariantCulture.NumberFormat),
+            Double.Parse(tokens[1].Trim(), CultureInfo.InvariantCulture.NumberFormat),
+            Double.Parse(tokens[2].Trim(), CultureInfo.InvariantCulture.NumberFormat));
       throw new NotSupportedException();
     }
 

--- a/Svg2Xaml/SvgTextElement.cs
+++ b/Svg2Xaml/SvgTextElement.cs
@@ -55,6 +55,8 @@ namespace Svg2Xaml
 
     public readonly SvgCoordinate Y;
 
+    public readonly string TextAnchor;
+
     //==========================================================================
     public SvgTextElement(SvgDocument document, SvgBaseElement parent, XElement svgElement)
       : base(document, parent, svgElement)
@@ -82,6 +84,9 @@ namespace Svg2Xaml
 
       var wordSpacingAttr = svgElement.Attribute("word-spacing");
       var wordSpacingStr = wordSpacingAttr != null ? wordSpacingAttr.Value : "0px";
+      
+      var textAnchorAttr = svgElement.Attribute("text-anchor");
+      TextAnchor = textAnchorAttr != null ? textAnchorAttr.Value : "start";
 
       var xAttr = svgElement.Attribute("x");
       this.X = xAttr != null ? SvgCoordinate.Parse(xAttr.Value) : null;
@@ -127,7 +132,21 @@ namespace Svg2Xaml
             this.Fill.ToBrush(this));
           var x = this.X != null ? this.X.Value : 0.0;
           var y = this.Y != null ? this.Y.Value : 0.0;
-          var pt = new Point(x, y - ft.Baseline);
+          Point pt;
+          switch(TextAnchor)
+          { 
+            case "middle":
+              pt = new Point(x - ft.WidthIncludingTrailingWhitespace / 2, y - ft.Baseline);
+              break;
+            case "end":
+              pt = new Point(x - ft.WidthIncludingTrailingWhitespace, y - ft.Baseline);
+              break;
+            case "start":
+            case "inherit":
+            default:
+              pt = new Point(x, y - ft.Baseline);
+              break;
+        }
           // Bei SVG scheint der Punkt die Basislinie des Textes zu meinen und
           // bei WPF die obere linke Ecke. Daher dieser Hack.
           dc.DrawText(ft, pt);

--- a/Svg2Xaml/SvgTextElement.cs
+++ b/Svg2Xaml/SvgTextElement.cs
@@ -107,7 +107,7 @@ namespace Svg2Xaml
       {
         if (firstSubNode.NodeType == XmlNodeType.Text)
         {
-          this.Text = firstSubNode.ToString();
+          this.Text = ((XText)firstSubNode).Value;
         }
         else
         {

--- a/Svg2Xaml/SvgTransform.cs
+++ b/Svg2Xaml/SvgTransform.cs
@@ -129,7 +129,7 @@ namespace Svg2Xaml
             int index = transform.IndexOf(")");
             if(index >= 0)
             {
-              transforms.Add(SvgScaleTransform.Parse(transform.Substring(0, index).Trim()));
+              transforms.Add(SvgRotateTransform.Parse(transform.Substring(0, index).Trim()));
               transform = transform.Substring(index + 1).TrimStart();
               continue;
             }


### PR DESCRIPTION
1.SvgImageElement class don't support svg+xml image,so I add it.
2.When SvgImageElement class load a image,it create a temp file,and never delete it.I make a change to use MemoryStream not use temp file.